### PR TITLE
Add `KeyDecoder`/`KeyEncoder` to Circe integrations

### DIFF
--- a/integration-circe/all/shared/src/main/scala/monix/newtypes/integrations/DerivedCirceKeyCodec.scala
+++ b/integration-circe/all/shared/src/main/scala/monix/newtypes/integrations/DerivedCirceKeyCodec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021-2024 Alexandru Nedelcu.
+ * See the project homepage at: https://newtypes.monix.io/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.newtypes
+package integrations
+
+import io.circe.{KeyEncoder, KeyDecoder}
+
+/** Derives a type-class instances for encoding and decoding JSON object keys
+  * for any type implementing [[HasExtractor]] and [[HasBuilder]] type-class
+  * instances.
+  *
+  * See
+  * [[https://circe.github.io/circe/codecs/custom-codecs.html#custom-key-types]].
+  */
+trait DerivedCirceKeyCodec
+    extends DerivedCirceKeyDecoder
+    with DerivedCirceKeyEncoder
+
+/** Derives a `io.circe.KeyDecoder` type-class instance for decoding a JSON
+  * object key to any type with a [[HasBuilder]] instance.
+  *
+  * See
+  * [[https://circe.github.io/circe/codecs/custom-codecs.html#custom-key-types]].
+  */
+trait DerivedCirceKeyDecoder {
+  implicit def jsonKeyDecoder[T, S](implicit
+      builder: HasBuilder.Aux[T, S],
+      dec: KeyDecoder[S]
+  ): KeyDecoder[T] = {
+    jsonKeyDecode(_)
+  }
+
+  protected def jsonKeyDecode[T, S](s: String)(implicit
+      builder: HasBuilder.Aux[T, S],
+      dec: KeyDecoder[S]
+  ): Option[T] = {
+    dec.apply(s).flatMap {
+      builder.build(_).toOption
+    }
+  }
+}
+
+/** Derives a `io.circe.KeyEncoder` type-class instance for encoding any type
+  * with a [[HasExtractor]] instance to a JSON object key.
+  *
+  * See
+  * [[https://circe.github.io/circe/codecs/custom-codecs.html#custom-key-types]].
+  */
+trait DerivedCirceKeyEncoder {
+  implicit def jsonKeyEncoder[T, S](implicit
+      extractor: HasExtractor.Aux[T, S],
+      enc: KeyEncoder[S]
+  ): KeyEncoder[T] = {
+    jsonKeyEncode(_)
+  }
+
+  protected def jsonKeyEncode[T, S](a: T)(implicit
+      extractor: HasExtractor.Aux[T, S],
+      enc: KeyEncoder[S]
+  ): String = {
+    enc.apply(extractor.extract(a))
+  }
+}

--- a/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewsubtypeCirceKeyCodecSuite.scala
+++ b/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewsubtypeCirceKeyCodecSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021-2024 Alexandru Nedelcu.
+ * See the project homepage at: https://newtypes.monix.io/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.newtypes
+package integrations
+
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+
+class NewsubtypeCirceKeyCodecSuite extends AnyFunSuite with EitherValues {
+  import NewsubtypeCirceKeyCodecSuite._
+
+  test("NewsubtypeWrapped has JSON key codec") {
+    val originalMap = Map(23459 -> "")
+    val expectedMap = Map(Text("23459") -> "")
+
+    // Check KeyEncoder.
+    val expectedJson = originalMap.asJson
+    val receivedJson = expectedMap.asJson
+    assert(receivedJson == expectedJson)
+
+    // Check KeyDecoder.
+    val receivedMap = expectedJson.as[Map[Text, String]]
+    assert(receivedMap == Right(expectedMap))
+  }
+
+  test("NewsubtypeValidated has JSON key codec") {
+    val originalMap = Map(0x7f -> "")
+    val expectedMap = PosByte(0x7f).map(k => Map(k -> "")).value
+
+    // Check KeyEncoder.
+    val expectedJson = originalMap.asJson
+    val receivedJson = expectedMap.asJson
+    assert(receivedJson == expectedJson)
+
+    // Check KeyDecoder.
+    val receivedMap = expectedJson.as[Map[PosByte, String]]
+    assert(receivedMap == Right(expectedMap))
+  }
+
+  // NOTE: Circe does not allow custom error messages in KeyDecoder.
+  test("NewsubtypeValidated JSON key decoder does validation") {
+    val received = Map(0 -> "").asJson.as[Map[PosByte, String]]
+    assert(received.isLeft)
+  }
+}
+
+object NewsubtypeCirceKeyCodecSuite {
+  type Text = Text.Type
+  object Text extends NewsubtypeWrapped[String] with DerivedCirceKeyCodec
+
+  type PosByte = PosByte.Type
+  object PosByte extends NewsubtypeValidated[Byte] with DerivedCirceKeyCodec {
+    override def apply(value: Byte): Either[BuildFailure[Type], Type] =
+      Either.cond(
+        value > 0,
+        unsafe(value),
+        BuildFailure() // message is not used by KeyDecoder anyway
+      )
+  }
+}

--- a/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewtypeCirceKeyCodecSuite.scala
+++ b/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewtypeCirceKeyCodecSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021-2024 Alexandru Nedelcu.
+ * See the project homepage at: https://newtypes.monix.io/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.newtypes
+package integrations
+
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+
+class NewtypeCirceKeyCodecSuite extends AnyFunSuite with EitherValues {
+  import NewtypeCirceKeyCodecSuite._
+
+  test("NewtypeWrapped has JSON key codec") {
+    val originalMap = Map(12347 -> "")
+    val expectedMap = Map(Text("12347") -> "")
+
+    // Check KeyEncoder.
+    val expectedJson = originalMap.asJson
+    val receivedJson = expectedMap.asJson
+    assert(receivedJson == expectedJson)
+
+    // Check KeyDecoder.
+    val receivedMap = expectedJson.as[Map[Text, String]]
+    assert(receivedMap == Right(expectedMap))
+  }
+
+  test("NewtypeValidated has JSON key codec") {
+    val originalMap = Map(0x7f -> "")
+    val expectedMap = PosByte(0x7f).map(k => Map(k -> "")).value
+
+    // Check KeyEncoder.
+    val expectedJson = originalMap.asJson
+    val receivedJson = expectedMap.asJson
+    assert(receivedJson == expectedJson)
+
+    // Check KeyDecoder.
+    val receivedMap = expectedJson.as[Map[PosByte, String]]
+    assert(receivedMap == Right(expectedMap))
+  }
+
+  // NOTE: Circe does not allow custom error messages in KeyDecoder.
+  test("NewtypeValidated JSON key decoder does validation") {
+    val received = Map(0 -> "").asJson.as[Map[PosByte, String]]
+    assert(received.isLeft)
+  }
+}
+
+object NewtypeCirceKeyCodecSuite {
+  type Text = Text.Type
+  object Text extends NewtypeWrapped[String] with DerivedCirceKeyCodec
+
+  type PosByte = PosByte.Type
+  object PosByte extends NewtypeValidated[Byte] with DerivedCirceKeyCodec {
+    override def apply(value: Byte): Either[BuildFailure[Type], Type] =
+      Either.cond(
+        value > 0,
+        unsafe(value),
+        BuildFailure() // message is not used by KeyDecoder anyway
+      )
+  }
+}

--- a/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewtypeKCirceKeyCodecSuite.scala
+++ b/integration-circe/all/shared/src/test/scala/monix/newtypes/integrations/NewtypeKCirceKeyCodecSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021-2024 Alexandru Nedelcu.
+ * See the project homepage at: https://newtypes.monix.io/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.newtypes
+package integrations
+
+import cats.Id
+import io.circe.syntax._
+import org.scalatest.funsuite.AnyFunSuite
+
+class NewtypeKCirceKeyCodecSuite extends AnyFunSuite {
+  import NewtypeKCirceKeyCodecSuite._
+
+  test("NewtypeK has JSON key codec") {
+    val expectedI = Map(NewId(12358) -> "")
+    val expectedS = Map(NewId("12358") -> "")
+
+    val jsonI = expectedI.asJson
+    val jsonS = expectedS.asJson
+
+    val receivedI2I = jsonI.as[Map[NewId[Int], String]]
+    assert(receivedI2I == Right(expectedI))
+
+    val receivedI2S = jsonI.as[Map[NewId[String], String]]
+    assert(receivedI2S == Right(expectedS))
+
+    val receivedS2I = jsonS.as[Map[NewId[Int], String]]
+    assert(receivedS2I == Right(expectedI))
+
+    val obtainedS2S = jsonS.as[Map[NewId[String], String]]
+    assert(obtainedS2S == Right(expectedS))
+  }
+
+  // NOTE: Circe does not allow custom error messages in KeyDecoder.
+  test("NewtypeK JSON key codec does validation") {
+    val map = Map(NewId("ABCDEFG") -> "")
+    val json = map.asJson
+    val received = json.as[Map[NewId[Int], String]]
+    assert(received.isLeft)
+  }
+}
+
+object NewtypeKCirceKeyCodecSuite {
+  type NewId[A] = NewId.Type[A]
+
+  object NewId extends NewtypeK[Id] with DerivedCirceKeyCodec {
+    def apply[A](a: A): NewId[A] = unsafeCoerce(a)
+
+    implicit def builder[A]: HasBuilder.Aux[Type[A], A] =
+      new HasBuilder[Type[A]] {
+        type Source = A
+        def build(value: A) = Right(apply(value))
+      }
+  }
+}


### PR DESCRIPTION
Introduces `DerivedCirceKeyCodec` along with `DerivedCirceKeyDecoder` and `DerivedCirceKeyEncoder` to provide support for keys in Circe.

Seems to be a pretty straightforward addition. The code mostly follows the pattern in `DerivedCirceCodec` and its counterparts.
